### PR TITLE
art: add check for __ARM_FEATURE_ATOMICS that indicates LSE atomics a…

### DIFF
--- a/runtime/arch/arm64/instruction_set_features_arm64.cc
+++ b/runtime/arch/arm64/instruction_set_features_arm64.cc
@@ -216,8 +216,7 @@ Arm64FeaturesUniquePtr Arm64InstructionSetFeatures::FromCppDefines() {
   has_crc = true;
 #endif
 
-#if defined (__ARM_ARCH_8_1A__) || defined (__ARM_ARCH_8_2A__)
-  // There is no specific ACLE macro defined for ARMv8.1 LSE features.
+#if defined (__ARM_FEATURE_ATOMICS)
   has_lse = true;
 #endif
 


### PR DESCRIPTION
…vailability on target

fixes: Mismatch between dex2oat instruction set features to use (ISA: Arm64 Feature string: -a53,crc,lse,fp16,dotprod,-sve) and those from CPP defines (ISA: Arm64 Feature string: -a53,crc,-lse,fp16,dotprod,-sve)

Still required, change wasn't merged on AOSP side.