### PR TITLE
ART: fixes for wrongly specified CPP defaults

### DIFF
--- a/dex2oat/dex2oat.cc
+++ b/dex2oat/dex2oat.cc
@@ -816,6 +816,13 @@ class Dex2Oat final {
     if (compiler_options_->instruction_set_ == kRuntimeISA) {
       std::unique_ptr<const InstructionSetFeatures> runtime_features(
           InstructionSetFeatures::FromCppDefines());
+      if (kRuntimeISA == InstructionSet::kArm64) {
+         std::unique_ptr<const InstructionSetFeatures> arm64_runtime_features(
+             InstructionSetFeatures::FromRuntimeDetection());
+         if (arm64_runtime_features != nullptr) {
+           runtime_features = std::move(arm64_runtime_features);
+         }
+      }
       if (!compiler_options_->GetInstructionSetFeatures()->Equals(runtime_features.get())) {
         LOG(WARNING) << "Mismatch between dex2oat instruction set features to use ("
             << *compiler_options_->GetInstructionSetFeatures()

--- a/runtime/arch/arm64/instruction_set_features_arm64.cc
+++ b/runtime/arch/arm64/instruction_set_features_arm64.cc
@@ -216,8 +216,7 @@ Arm64FeaturesUniquePtr Arm64InstructionSetFeatures::FromCppDefines() {
   has_crc = true;
 #endif
 
-#if defined (__ARM_ARCH_8_1A__) || defined (__ARM_ARCH_8_2A__)
-  // There is no specific ACLE macro defined for ARMv8.1 LSE features.
+#if defined (__ARM_FEATURE_ATOMICS)
   has_lse = true;
 #endif
 

--- a/runtime/arch/instruction_set_features.cc
+++ b/runtime/arch/instruction_set_features.cc
@@ -129,7 +129,7 @@ std::unique_ptr<const InstructionSetFeatures> InstructionSetFeatures::FromRuntim
   switch (kRuntimeISA) {
 #ifdef ART_TARGET_ANDROID
     case InstructionSet::kArm64:
-      return Arm64InstructionSetFeatures::FromHwcap();
+      return Arm64InstructionSetFeatures::FromHwcap()->IntersectWithHwcap();
 #endif
     default:
       return nullptr;


### PR DESCRIPTION
Howdy.
I've been over this for some time now, and think this'll be better as this actually checks the hardware in use for capabilities instead of blindly depending on compiler to have all the neccessary bits in place.
Thing is, clang (and any other compiler really) won't do until you ask it to do so, and as a result depending on ARM_FEATURE is depending on mcpu-march flags to be provided correctly.
AOSP doesn't do that, but there's a way we can instead check the TARGET_CPU_VARIANT and hardware reported capabilities to actually optimize for hardware in place.